### PR TITLE
fix(menu): Owerflow not scrollable in filter menu

### DIFF
--- a/apps/www/components/shell/AsideFilter.tsx
+++ b/apps/www/components/shell/AsideFilter.tsx
@@ -49,7 +49,7 @@ const style = tv({
   base: "",
   slots: {
     sticky: "sticky top-16 pt-10",
-    body: "verflow-y-auto md:max-w-[333px] md:pb-28 xl:mx-16",
+    body: "max-h-[100vh] overflow-y-auto md:max-w-[333px]  md:pb-28 xl:mx-16",
     title: "pl-3 text-2xl font-bold uppercase text-Congress_Blue md:pl-0",
     subtitle: "w-full px-4 pb-6 pt-4 text-base md:px-0",
     article: "w-full",


### PR DESCRIPTION
<p align =center>${\color{lightgreen}FIX}$ </p></p><p align=center><img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaHVva2NzYmh6dmt0bWdsbXh2azN0NmYwdms4cGpnaXhybmxxZ3B2eSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/4xWGyVKoXqg2eVCiq9/giphy.gif"></p><p align =right>fix #1821 </p>